### PR TITLE
[BUG]Remove unnecessary renders in LayoutRender

### DIFF
--- a/src/Thinreports/Generator/Renderer/LayoutRenderer.php
+++ b/src/Thinreports/Generator/Renderer/LayoutRenderer.php
@@ -45,7 +45,7 @@ class LayoutRenderer extends AbstractRenderer
             $attributes = $item;
             $type = $item['type'];
 
-            if (!($type === 'text' || $type === 'image' || $type === 'rect' || $type === 'ellipse' || $type === 'line')) {
+            if (!($type === 'text' || $type === 'image')) {
                 continue;
             }
 


### PR DESCRIPTION
## Overview

In LayoutRender, no rendering is required except for text and image, so they were deleted.