### PR TITLE
Fix static text item rendering to use item style data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.pdf
 composer.lock
 vendor/
+
+.idea
+
+.phpunit.result.cache
+.phpunit.cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Thinreports PHP is a PDF generation library for PHP that uses Thinreports Editor layout files (.tlf). It provides an API for generating PDFs from template layouts created with Thinreports Editor 0.8.x.
+
+## Commands
+
+```bash
+# Run all tests (unit and feature)
+composer test
+
+# Run a single test file
+./vendor/bin/phpunit test/unit/Thinreports/ReportTest.php
+
+# Run a specific test method
+./vendor/bin/phpunit --filter testMethodName test/unit/Thinreports/ReportTest.php
+
+# Run static analysis
+composer phpstan
+```
+
+## Architecture
+
+### Core Components
+
+- **Report** (`src/Thinreports/Report.php`): Main entry point. Manages pages and layouts, coordinates PDF generation via `PDFGenerator::generate()`.
+
+- **Layout** (`src/Thinreports/Layout.php`): Parses .tlf JSON files (Thinreports Editor format). Creates item instances based on schema. Compatible with layout versions >= 0.8.2 and < 1.0.0.
+
+- **Page** (`src/Thinreports/Page/Page.php`): Represents a single PDF page. Provides `item($id)` to access layout items and set values/styles.
+
+### Item Types
+
+Located in `src/Thinreports/Item/`:
+- `TextBlockItem` - Dynamic text with formatting
+- `ImageBlockItem` - Dynamic images (base64 or file path)
+- `PageNumberItem` - Page number display
+- `BasicItem` - Static layout elements (text, rect, ellipse, line, image)
+
+Each item has an associated style class in `src/Thinreports/Item/Style/`.
+
+### PDF Generation Flow
+
+1. `Report::generate()` calls `PDFGenerator::generate()`
+2. `PDFGenerator` iterates pages and delegates to:
+   - `LayoutRenderer` - Renders static layout elements (text, images, shapes)
+   - `ItemRenderer` - Renders dynamic items with user-set values
+3. Both renderers use `PDF\Document` which wraps TCPDF
+
+### PDF Helpers
+
+Located in `src/Thinreports/Generator/PDF/`:
+- `Document` - TCPDF wrapper, page management
+- `Graphics` - Shape drawing (rect, ellipse, line, images)
+- `Text` - Text box rendering with alignment/formatting
+- `Font` - Font family mapping
+- `ColorParser` - Hex color to RGB conversion
+
+## Testing
+
+- **Unit tests**: `test/unit/Thinreports/` - Mirror src structure, suffix `*Test.php`
+- **Feature tests**: `test/feature/` - End-to-end PDF generation tests, suffix `*Feature.php`
+- **Test layouts**: Feature tests use .tlf files in their respective directories
+
+## Layout File Format
+
+.tlf files are JSON containing:
+- `version`: Layout format version
+- `title`: Report title
+- `report`: Paper settings (paper-type, orientation, width, height)
+- `items`: Array of item definitions with type, position, dimensions, styles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Thinreports PHP is a PDF generation library for PHP that uses Thinreports Editor layout files (.tlf). It provides an API for generating PDFs from template layouts created with Thinreports Editor 0.8.x.
+
+## Commands
+
+```bash
+# Run all tests (unit and feature)
+composer test
+
+# Run a single test file
+./vendor/bin/phpunit test/unit/Thinreports/ReportTest.php
+
+# Run a specific test method
+./vendor/bin/phpunit --filter testMethodName test/unit/Thinreports/ReportTest.php
+
+# Run static analysis
+composer phpstan
+```
+
+## Architecture
+
+### Core Components
+
+- **Report** (`src/Thinreports/Report.php`): Main entry point. Manages pages and layouts, coordinates PDF generation via `PDFGenerator::generate()`.
+
+- **Layout** (`src/Thinreports/Layout.php`): Parses .tlf JSON files (Thinreports Editor format). Creates item instances based on schema. Compatible with layout versions >= 0.8.2 and < 1.0.0.
+
+- **Page** (`src/Thinreports/Page/Page.php`): Represents a single PDF page. Provides `item($id)` to access layout items and set values/styles.
+
+### Item Types
+
+Located in `src/Thinreports/Item/`:
+- `TextBlockItem` - Dynamic text with formatting
+- `ImageBlockItem` - Dynamic images (base64 or file path)
+- `PageNumberItem` - Page number display
+- `BasicItem` - Static layout elements (text, rect, ellipse, line, image)
+
+Each item has an associated style class in `src/Thinreports/Item/Style/`.
+
+### PDF Generation Flow
+
+1. `Report::generate()` calls `PDFGenerator::generate()`
+2. `PDFGenerator` iterates pages and delegates to:
+   - `LayoutRenderer` - Renders static layout elements (text, images, shapes)
+   - `ItemRenderer` - Renders dynamic items with user-set values
+3. Both renderers use `PDF\Document` which wraps TCPDF
+
+### PDF Helpers
+
+Located in `src/Thinreports/Generator/PDF/`:
+- `Document` - TCPDF wrapper, page management
+- `Graphics` - Shape drawing (rect, ellipse, line, images)
+- `Text` - Text box rendering with alignment/formatting
+- `Font` - Font family mapping
+- `ColorParser` - Hex color to RGB conversion
+
+## Testing
+
+- **Unit tests**: `test/unit/Thinreports/` - Mirror src structure, suffix `*Test.php`
+- **Feature tests**: `test/feature/` - End-to-end PDF generation tests, suffix `*Feature.php`
+- **Test layouts**: Feature tests use .tlf files in their respective directories
+
+## Layout File Format
+
+.tlf files are JSON containing:
+- `version`: Layout format version
+- `title`: Report title
+- `report`: Paper settings (paper-type, orientation, width, height)
+- `items`: Array of item definitions with type, position, dimensions, styles

--- a/src/Thinreports/Generator/Renderer/ItemRenderer.php
+++ b/src/Thinreports/Generator/Renderer/ItemRenderer.php
@@ -195,7 +195,7 @@ class ItemRenderer extends AbstractRenderer
             $bounds['y'],
             $bounds['width'],
             $bounds['height'],
-            $this->buildTextStyles($schema)
+            $this->buildTextStyles($schema['style'])
         );
     }
 

--- a/test/feature/text_rendering/TextRenderingFeature.php
+++ b/test/feature/text_rendering/TextRenderingFeature.php
@@ -18,6 +18,18 @@ class TextRenderingFeature extends FeatureTest
         $this->assertRenderingTextAndFont($report);
     }
 
+    public function test_staticTextWithIdRendering(): void
+    {
+        $report = new Thinreports\Report(__DIR__ . '/layouts/static_text_with_id.tlf');
+        $page = $report->addPage();
+        $page->item('label_prefecture_number')->show();
+
+        $analyzer = $this->analyzePDF($report->generate());
+
+        $this->assertStringContainsString('都道府県番号', $analyzer->getTextsInPage(1));
+        $this->assertContains('IPAMincho', $analyzer->getFontsInPage(1));
+    }
+
     public function test_dynamicTextRenderingWithProperlyFont(): void
     {
         $report = new Thinreports\Report(__DIR__ . '/layouts/dynamic_texts.tlf');

--- a/test/feature/text_rendering/layouts/static_text_with_id.tlf
+++ b/test/feature/text_rendering/layouts/static_text_with_id.tlf
@@ -1,0 +1,40 @@
+{
+  "version": "0.9.0",
+  "title": "",
+  "report": {
+    "paper-type": "A4",
+    "width": 0.0,
+    "height": 0.0,
+    "orientation": "portrait",
+    "margin": [
+      20.0,
+      20.0,
+      20.0,
+      20.0
+    ]
+  },
+  "items": [
+    {
+      "id": "label_prefecture_number",
+      "type": "text",
+      "x": 20.0,
+      "y": 20.0,
+      "width": 176.3,
+      "height": 21.0,
+      "display": false,
+      "style": {
+        "font-family": [
+          "IPAMincho"
+        ],
+        "font-size": 8,
+        "color": "#595959",
+        "text-align": "left",
+        "letter-spacing": "",
+        "font-style": []
+      },
+      "texts": [
+        "都道府県番号"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Pass the static text item's `style` block into text style rendering instead of the full schema.
- Add a feature test covering a hidden text item rendered by ID to verify the expected text and font are preserved.
- Update repository ignore rules for local IDE and PHPUnit cache files.

## Testing
- Added feature coverage for static text rendering with an item ID.
- Not run (not requested).