### PR TITLE
Fix dynamic graphic style rendering for basic items

### DIFF
--- a/src/Thinreports/Generator/Renderer/ItemRenderer.php
+++ b/src/Thinreports/Generator/Renderer/ItemRenderer.php
@@ -204,18 +204,14 @@ class ItemRenderer extends AbstractRenderer
      */
     public function renderRectItem(Item\BasicItem $item): void
     {
-//        $schema = $item->getSchema();
         $bounds = $item->getBounds();
-
-//        $styles = $this->buildGraphicStyles($schema);
-//        $styles['radius'] = $schema['border-radius'];
 
         $this->doc->graphics->drawRect(
             $bounds['x'],
             $bounds['y'],
             $bounds['width'],
             $bounds['height'],
-            $this->buildGraphicStyles($item->exportStyles())
+            $this->buildBasicItemGraphicStyles($item)
         );
     }
 
@@ -231,7 +227,7 @@ class ItemRenderer extends AbstractRenderer
             $bounds['cy'],
             $bounds['rx'],
             $bounds['ry'],
-            $this->buildGraphicStyles($item->exportStyles())
+            $this->buildBasicItemGraphicStyles($item)
         );
     }
 
@@ -247,8 +243,16 @@ class ItemRenderer extends AbstractRenderer
             $bounds['y1'],
             $bounds['x2'],
             $bounds['y2'],
-            $this->buildGraphicStyles($item->exportStyles())
+            $this->buildBasicItemGraphicStyles($item)
         );
+    }
+
+    private function buildBasicItemGraphicStyles(Item\BasicItem $item): array
+    {
+        $schema = $item->getSchema();
+        $styles = array_merge($schema['style'], $item->exportStyles());
+
+        return $this->buildGraphicStyles($styles);
     }
 
     /**

--- a/test/feature/graphic_rendering/GraphicRenderingFeature.php
+++ b/test/feature/graphic_rendering/GraphicRenderingFeature.php
@@ -1,0 +1,55 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+require_once __DIR__ . '/../test_helper.php';
+
+class GraphicRenderingFeature extends FeatureTest
+{
+    #[DataProvider('graphicItemProvider')]
+    public function test_graphicItemWithIdRendering(string $item_id, string $expected_pattern): void
+    {
+        $report = new Thinreports\Report(__DIR__ . '/layouts/graphics_with_ids.tlf');
+        $page = $report->addPage();
+        $page->item($item_id)->show();
+
+        $analyzer = $this->analyzePDF($report->generate());
+
+        $this->assertMatchesRegularExpression(
+            $expected_pattern,
+            $analyzer->getRawContentInPage(1)
+        );
+    }
+
+    public function test_graphicItemWithIdRenderingUpdatedStyle(): void
+    {
+        $report = new Thinreports\Report(__DIR__ . '/layouts/graphics_with_ids.tlf');
+        $page = $report->addPage();
+        $page->item('line_with_id')->show()->setStyle('border_width', 2);
+
+        $analyzer = $this->analyzePDF($report->generate());
+
+        $this->assertMatchesRegularExpression(
+            '/2\.000000 w .* RG\s+20\.000000 821\.890000 m/s',
+            $analyzer->getRawContentInPage(1)
+        );
+    }
+
+    public static function graphicItemProvider(): array
+    {
+        return array(
+            'line' => array(
+                'line_with_id',
+                '/20\.000000 821\.890000 m\s+80\.000000 821\.890000 l\s+S/'
+            ),
+            'rect' => array(
+                'rect_with_id',
+                '/20\.000000 801\.890000 40\.000000 -20\.000000 re S/'
+            ),
+            'ellipse' => array(
+                'ellipse_with_id',
+                '/120\.000000 791\.890000 m\s+(?:[0-9.\s]+c\s+)+S/'
+            )
+        );
+    }
+}

--- a/test/feature/graphic_rendering/layouts/graphics_with_ids.tlf
+++ b/test/feature/graphic_rendering/layouts/graphics_with_ids.tlf
@@ -1,0 +1,63 @@
+{
+  "version": "0.9.0",
+  "title": "",
+  "report": {
+    "paper-type": "A4",
+    "width": 0.0,
+    "height": 0.0,
+    "orientation": "portrait",
+    "margin": [
+      20.0,
+      20.0,
+      20.0,
+      20.0
+    ]
+  },
+  "items": [
+    {
+      "id": "line_with_id",
+      "type": "line",
+      "display": false,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "solid"
+      },
+      "x1": 20.0,
+      "y1": 20.0,
+      "x2": 80.0,
+      "y2": 20.0
+    },
+    {
+      "id": "rect_with_id",
+      "type": "rect",
+      "display": false,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "none"
+      },
+      "x": 20.0,
+      "y": 40.0,
+      "width": 40.0,
+      "height": 20.0,
+      "border-radius": 0
+    },
+    {
+      "id": "ellipse_with_id",
+      "type": "ellipse",
+      "display": false,
+      "style": {
+        "border-color": "#000000",
+        "border-width": 1,
+        "border-style": "solid",
+        "fill-color": "none"
+      },
+      "cx": 100.0,
+      "cy": 50.0,
+      "rx": 20.0,
+      "ry": 10.0
+    }
+  ]
+}

--- a/test/feature/test_helper.php
+++ b/test/feature/test_helper.php
@@ -74,6 +74,11 @@ class PDFAnalyzer
         );
     }
 
+    public function getRawContentInPage($page_number): string
+    {
+        return $this->pages[$page_number - 1]->get('Contents')->getContent();
+    }
+
     public function isEmptyPage($page_number): bool
     {
         $texts = str_replace(


### PR DESCRIPTION
## Summary
- Merge layout-defined styles with runtime styles when rendering `rect`, `ellipse`, and `line` basic items.
- Restore correct border styling for items referenced by ID when styles are updated dynamically.
- Add feature coverage for raw PDF content emitted by graphic items.

## Testing
- Added feature tests for line, rect, and ellipse rendering with item IDs.
- Added a regression test covering `border_width` updates on a rendered graphic item.